### PR TITLE
[ fix ] Fix erroneous name redefinitions in generated code

### DIFF
--- a/src/Test/Verilog/Pretty.idr
+++ b/src/Test/Verilog/Pretty.idr
@@ -94,7 +94,7 @@ data UniqNames : (l : Nat) -> SVect l -> Type where
 public export
 data NameIsNew : (l : Nat) -> (names: SVect l) -> (name: String) -> UniqNames l names -> Type where
   NNEmpty : NameIsNew 0 [] s Empty
-  NNCons : (0 _ : So $ x /= name) -> (nin: NameIsNew l xs x nn) -> (nin' : NameIsNew l xs name nn') -> NameIsNew (S l) (x :: xs) name (Cons xs x nn nin)
+  NNCons : (0 _ : So $ x /= name) -> (nin: NameIsNew l xs name nn) -> NameIsNew (S l) (x :: xs) name (Cons xs x nn nin)
 
 -- Minimize the signature while preserving the issue.
 export


### PR DESCRIPTION
This should fix #1 and fix #2 as they are both caused by the same bug - an unsound NameIsNew that did not have inductive properties. Due to that bug, it only proved non-equality with the first member of array rather than every member.